### PR TITLE
Cosmetic

### DIFF
--- a/js/jQuery.oppai.js
+++ b/js/jQuery.oppai.js
@@ -1,15 +1,17 @@
 (function($)
 {
+	"use strict";
+
 	$.fn.oppai = function(options)
 	{
 		var defaults = {
-			text : "( ﾟ∀ﾟ)o彡゜おっぱい！おっぱい！"
+			text: "( ﾟ∀ﾟ)o彡゜おっぱい！おっぱい！"
 		};
-		var setting = $.extend(defaults,options);
-	
+		var setting = $.extend(defaults, options);
+
 		this.each(function()
 		{
-			jQuery(this).html(jQuery(this).html().replace(/。/g,setting.text+"。"));
+			jQuery(this).html(jQuery(this).html().replace(/。/g, setting.text + "。"));
 		});
 		return (this);
 	};


### PR DESCRIPTION
Cosmetic follow eslint.
but, Don't correspond ` 'jQuery' is not defined.`

```
% eslint js/jQuery.oppai.js

js/jQuery.oppai.js
   1:1   error  Missing "use strict" statement  strict
   6:3   error  Extra space after key "text"    key-spacing
   8:33  error  A space is required after ','   comma-spacing
   9:1   error  Trailing spaces not allowed     no-trailing-spaces
  12:3   error  'jQuery' is not defined         no-undef
  12:21  error  'jQuery' is not defined         no-undef
  12:53  error  A space is required after ','   comma-spacing
  12:54  error  Infix operators must be spaced  space-infix-ops
  16:3   error  'jQuery' is not defined         no-undef

✖ 9 problems (9 errors, 0 warnings)
```